### PR TITLE
make sure issue_io() propagates RuntimeError exception to callers

### DIFF
--- a/libsgio.pyx
+++ b/libsgio.pyx
@@ -37,7 +37,7 @@ cdef class SCSIDevice(object):
 
     cdef int issue_io(self, unsigned char *cdb, unsigned char cdb_size,
             int xfer_dir, unsigned char *data, unsigned int *data_size,
-            unsigned char *sense, unsigned int *sense_len):
+            unsigned char *sense, unsigned int *sense_len) except -1:
 
         self.io.interface_id = b'S'
         self.io.cmdp = cdb

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from Cython.Build import cythonize
 
 setup(
     name='libsgio',
-    version='0.0.3',
+    version='0.0.4',
     setup_requires=[
         'setuptools>=45.0',
         'Cython',


### PR DESCRIPTION
From documentation

> ...functions defined as cdef or cpdef can return arbitrary C types, which do not have such a well-defined error return value. Thus, if an exception is detected in such a function, a warning message is printed, the exception is ignored, and the function returns immediately without propagating the exception to its caller.