### PR TITLE
fix many problems

### DIFF
--- a/libsgio.pyx
+++ b/libsgio.pyx
@@ -1,7 +1,8 @@
 # cython: language_level=3, c_string_type=unicode, c_string_encoding=default
+from enum import IntEnum
 from os import strerror
 
-from pxd cimport libsgio
+from pxd cimport libsgio, scsi
 
 from posix.ioctl cimport ioctl
 from posix.fcntl cimport open, O_RDONLY
@@ -9,6 +10,29 @@ from posix.unistd cimport close
 from libc.stdlib cimport calloc, free
 from libc.string cimport memset
 from libc.errno cimport errno
+
+
+class SCSIErrorException(Exception):
+    def __init__(self, message, sense_data, *args):
+        self.message = message
+        self.sense_data = sense_data
+        super(SCSIErrorException, self).__init__(message, sense_data, *args)
+
+
+class SCSI_OPCODES(IntEnum):
+    # as defined in SAM-6 spec at t10.org
+    GOOD = 0x0
+    CHECK_CONDITION = 0x02
+    CONDITION_MET = 0x04
+    BUSY = 0x08
+    OBSOLETE1 = 0x10
+    OBSOLETE2 = 0x14
+    RESERVATION_CONFLICT = 0x18
+    OBSOLETE3 = 0x22
+    TASK_SET_FULL = 0x28
+    ACA_ACTIVE = 0x30
+    TASK_ABORTED = 0x40
+    UNKNOWN = 0xff  # our own code
 
 
 cdef class SCSIDevice(object):
@@ -28,11 +52,7 @@ cdef class SCSIDevice(object):
             if self.dev_fd == -1:
                 raise OSError(errno, strerror(errno), self.device)
 
-        with nogil:
-            memset(&self.io, 0, sizeof(libsgio.sg_io_hdr_t))
-
     def __dealloc__(self):
-
         with nogil:
             if self.dev_fd >= 0:
                 close(self.dev_fd)
@@ -40,6 +60,9 @@ cdef class SCSIDevice(object):
     cdef int issue_io(self, unsigned char *cdb, unsigned char cdb_size,
             int xfer_dir, unsigned char *data, unsigned int *data_size,
             unsigned char *sense, unsigned int *sense_len) except -1:
+
+        with nogil:
+            memset(&self.io, 0, sizeof(libsgio.sg_io_hdr_t))
 
         self.io.interface_id = b'S'
         self.io.cmdp = cdb
@@ -58,83 +81,39 @@ cdef class SCSIDevice(object):
 
         with nogil:
             res = ioctl(self.dev_fd, libsgio.SG_IO, &self.io)
-            if res != 0:
-                raise RuntimeError()
+            if res < 0:
+                raise OSError(res, strerror(res))
 
-        # set sense_len if error occurred
+        cdef int check_sense_data = 0
         if (self.io.info & libsgio.SG_INFO_OK_MASK) != libsgio.SG_INFO_OK:
+            check_sense_data = 1
             if self.io.sb_len_wr > 0:
-                sense_len[0]=self.io.sb_len_wr
-                error_data = 1
+                # set sense_len if error occurred
+                sense_len[0] = self.io.sb_len_wr
+
+        return check_sense_data
 
     cdef format_sense_data(self, unsigned char *sense, unsigned int sense_len):
-
-        sensetable = {
-            1: 'no sense',
-            2: 'recovered error',
-            3: 'not ready',
-            4: 'medium error',
-            5: 'hardware error',
-            6: 'illegal request',
-            7: 'unit attention',
-            8: 'data protect',
-            9: 'blank check',
-            10: 'vendor specific',
-            11: 'copy aborted',
-            12: 'aborted command',
-            13: 'unknown',
-            14: 'unknown',
-            15: 'unknown',
-            16: 'unknown',
+        return {
+            'device_status': self.io.status,
+            'driver_status': self.io.driver_status,
+            'transport_status': self.io.host_status,
+            'response_len': self.io.sb_len_wr,
+            'duration': self.io.duration,
+            'din_resid': self.io.resid,
+            'raw_sense_buffer': [sense[i] for i in range(sense_len)],
         }
 
-        sense_info = {}
+    def raise_error(self, sense_data):
+        error_name = SCSI_OPCODES.UNKNOWN.name
+        for error in filter(lambda x: x.value == sense_data['device_status'], SCSI_OPCODES):
+            error_name = error.name
 
-        sense_info['status'] = '0x' + f'{self.io.status:02x}'
-        sense_info['masked_status'] = '0x' + f'{self.io.masked_status:02x}'
-        sense_info['host_status'] = '0x' + f'{self.io.host_status:02x}'
-        sense_info['driver_status'] = '0x' + f'{self.io.driver_status:02x}'
-
-        add_cmd = []
-        if sense[0] == 0x70:
-            sense_info['filemark'] = int((sense[2] & 0x80) != 0)
-            sense_info['eom'] = int((sense[2] & 0x40) != 0)
-            sense_info['ili'] = int((sense[2] & 0x20) != 0)
-            sense_info['sense_key'] = '0x' + f'{(sense[2] & 0x0f):02x}'
-            sense_info['error_msg'] = sensetable[(sense[2] & 0x0f)]
-
-            for i in range(8, 12):
-                add_cmd.append('0x' + f'{sense[i]:02x}')
-            sense_info['cmd_info'] = add_cmd
-
-            asc = ascq = None
-            asc = '0x' + f'{sense[12]:02x}'
-            ascq = '0x' + f'{sense[13]:02x}'
-            sense_info['additional_sense_code'] = asc
-            sense_info['additional_sense_code_qualifier'] = ascq
-            sense_info['field_replaceable_unit_code'] = '0x' + f'{sense[14]:02x}'
-
-            sense_info['invalid_cmd_op_code'] = False
-            if asc == 0x20 and ascq == 0x00:
-                sense_info['invalid_cmd_op_code'] = True
-
-        sense_info['raw_data'] = []
-        for i in range(0, sense_len + 1):
-            if isinstance(sense[i], str):
-                sense_info['raw_data'].append('0x' + sense[i])
-            elif isinstance(sense[i], int):
-                sense_info['raw_data'].append('0x' + f'{sense[i]:02x}')
-
-        return sense_info
+        raise SCSIErrorException(error_name, sense_data)
 
     def read_keys(self):
-        """
-        Read the registered keys on the disk
-        """
-
-        cdef unsigned char[10] cdb = [
-            0x5e, 0, 0, 0, 0, 0, 0, 0, 0, 0
-        ]
+        """Read the registered keys on the disk"""
+        cdef unsigned char[10] cdb = [scsi.PERSISTENT_RESERVE_IN, 0, 0, 0, 0, 0, 0, 0, 0, 0]
         cdef unsigned int data_size = 0x00ff
         cdef unsigned char[0x00ff] data
         cdef unsigned int sense_len = 32
@@ -149,23 +128,19 @@ cdef class SCSIDevice(object):
         cdb[7] = (data_size >> 8) & 0xff
         cdb[8] = data_size & 0xff
 
-        try:
-            self.issue_io(
-                cdb,
-                sizeof(cdb),
-                libsgio.SG_DXFER_FROM_DEV,
-                data,
-                &data_size,
-                sense,
-                &sense_len,
-            )
-        except RuntimeError:
-            # no reason to continue
-            raise
+        check_sense_data = self.issue_io(
+            cdb,
+            sizeof(cdb),
+            libsgio.SG_DXFER_FROM_DEV,
+            data,
+            &data_size,
+            sense,
+            &sense_len,
+        )
 
         # handle errors
-        if sense_len != 0:
-            raise OSError(self.format_sense_data(sense, sense_len))
+        if any((check_sense_data, sense_len)):
+            self.raise_error(self.format_sense_data(sense, sense_len))
 
         # prgeneration
         prgen = data[0]
@@ -202,13 +177,8 @@ cdef class SCSIDevice(object):
         }
 
     def read_reservation(self):
-        """
-        Read the persistent reservation key on the disk
-        """
-
-        cdef unsigned char[10] cdb = [
-            0x5e, 0, 0, 0, 0, 0, 0, 0, 0, 0
-        ]
+        """Read the persistent reservation key on the disk"""
+        cdef unsigned char[10] cdb = [scsi.PERSISTENT_RESERVE_IN, 0, 0, 0, 0, 0, 0, 0, 0, 0]
         cdef unsigned int data_size = 0x00ff
         cdef unsigned char[0x00ff] data
         cdef unsigned int sense_len = 32
@@ -222,23 +192,19 @@ cdef class SCSIDevice(object):
         cdb[7] = (data_size >> 8) & 0xff
         cdb[8] = data_size & 0xff
 
-        try:
-            self.issue_io(
-                cdb,
-                sizeof(cdb),
-                libsgio.SG_DXFER_FROM_DEV,
-                data,
-                &data_size,
-                sense,
-                &sense_len,
-            )
-        except RuntimeError:
-            # no reason to continue
-            raise
+        check_sense_data = self.issue_io(
+            cdb,
+            sizeof(cdb),
+            libsgio.SG_DXFER_FROM_DEV,
+            data,
+            &data_size,
+            sense,
+            &sense_len,
+        )
 
         # handle errors
-        if sense_len != 0:
-            raise OSError(self.format_sense_data(sense, sense_len))
+        if any((check_sense_data, sense_len)):
+            self.raise_error(self.format_sense_data(sense, sense_len))
 
         # prgeneration
         prgen = data[0]
@@ -282,72 +248,10 @@ cdef class SCSIDevice(object):
     
     def update_key(self, cur_key, new_key):
         """
-        Update an existing `cur_key` with the
-        `new_key`
+        If `cur_key` currently holds the reservation then the reservation key will be
+        updated to the `new_key`
         """
-
-        cdef unsigned char[10] cdb = [
-            0x5f, 0, 0, 0, 0, 0, 0, 0, 0, 0
-        ]
-        cdef unsigned int data_size = 24
-        cdef unsigned char[24] data
-        cdef unsigned int sense_len = 32
-        cdef unsigned char[32] sense
-        cdef unsigned int sa = 6
-        cdef int res
-
-        cdb[1] = sa
-        cdb[2] = (0 << 4) | 1  # scope = 0, type = 1
-        cdb[7] = (data_size >> 8) & 0xff
-        cdb[8] = data_size & 0xff
-
-        with nogil:
-            memset(data, 0, data_size)
-
-        # cur_key
-        pos = 56
-        for i in range(0, 7):
-            if pos == 0:
-                data[i] = cur_key & 0xff
-            else:
-                data[i] = (cur_key >> pos) & 0xff
-            pos -= 8
-
-        # new_key
-        pos = 56
-        for i in range(8, 16):
-            if pos == 0:
-                data[i] = new_key & 0xff
-            else:
-                data[i] = (new_key >> pos) & 0xff
-            pos -= 8
-
-        try:
-            self.issue_io(
-                cdb,
-                sizeof(cdb),
-                libsgio.SG_DXFER_TO_DEV,
-                data,
-                &data_size,
-                sense,
-                &sense_len,
-            )
-        except RuntimeError:
-            # no reason to continue
-            raise
-
-        # handle errors
-        if sense_len != 0:
-            raise OSError(self.format_sense_data(sense, sense_len))
-
-    def register_new_key(self, key):
-        """
-        Register a new key to the disk.
-        """
-
-        cdef unsigned char[10] cdb = [
-            0x5f, 0, 0, 0, 0, 0, 0, 0, 0, 0
-        ]
+        cdef unsigned char[10] cdb = [scsi.PERSISTENT_RESERVE_OUT, 0, 0, 0, 0, 0, 0, 0, 0, 0]
         cdef unsigned int data_size = 24
         cdef unsigned char[24] data
         cdef unsigned int sense_len = 32
@@ -363,14 +267,55 @@ cdef class SCSIDevice(object):
         with nogil:
             memset(data, 0, data_size)
 
-        # where an existing key would be put
-        # if an existing one was registered
-        # by this host so fill with 0's
-        # since this method implies that
-        # there are no current keys
-        # registered by this host
+        # cur_key
+        pos = 56
         for i in range(0, 8):
-            data[i] = 0
+            if pos == 0:
+                data[i] = cur_key & 0xff
+            else:
+                data[i] = (cur_key >> pos) & 0xff
+            pos -= 8
+
+        # new_key
+        pos = 56
+        for i in range(8, 16):
+            if pos == 0:
+                data[i] = new_key & 0xff
+            else:
+                data[i] = (new_key >> pos) & 0xff
+            pos -= 8
+
+        check_sense_data = self.issue_io(
+            cdb,
+            sizeof(cdb),
+            libsgio.SG_DXFER_TO_DEV,
+            data,
+            &data_size,
+            sense,
+            &sense_len,
+        )
+
+        # handle errors
+        if any((check_sense_data, sense_len)):
+            self.raise_error(self.format_sense_data(sense, sense_len))
+
+    def register_new_key(self, key):
+        """Register a new key to the disk."""
+        cdef unsigned char[10] cdb = [scsi.PERSISTENT_RESERVE_OUT, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+        cdef unsigned int data_size = 24
+        cdef unsigned char[24] data
+        cdef unsigned int sense_len = 32
+        cdef unsigned char[32] sense
+        cdef unsigned int sa = 0
+        cdef int res
+
+        cdb[1] = sa
+        cdb[2] = (0 << 4) | 1  # scope = 0, type = 1
+        cdb[7] = (data_size >> 8) & 0xff
+        cdb[8] = data_size & 0xff
+
+        with nogil:
+            memset(data, 0, data_size)
 
         # key
         pos = 56
@@ -381,34 +326,25 @@ cdef class SCSIDevice(object):
                 data[i] = (key >> pos) & 0xff
             pos -= 8
 
-        try:
-            self.issue_io(
-                cdb,
-                sizeof(cdb),
-                libsgio.SG_DXFER_TO_DEV,
-                data,
-                &data_size,
-                sense,
-                &sense_len,
-            )
-        except RuntimeError:
-            # no reason to continue
-            raise
+        check_sense_data = self.issue_io(
+            cdb,
+            sizeof(cdb),
+            libsgio.SG_DXFER_TO_DEV,
+            data,
+            &data_size,
+            sense,
+            &sense_len,
+        )
 
         # handle errors
-        if sense_len != 0:
-            raise OSError(self.format_sense_data(sense, sense_len))
+        if any((check_sense_data, sense_len)):
+            self.raise_error(self.format_sense_data(sense, sense_len))
 
     def register_ignore_key(self, key):
         """
-        Regsiters a `key` to a disk ignoring
-        any keys that already exist that are owned
-        by this host.
+        Regsiters a `key` to a disk ignoring any keys that already exist that are owned by this host.
         """
-
-        cdef unsigned char[10] cdb = [
-            0x5f, 0, 0, 0, 0, 0, 0, 0, 0, 0
-        ]
+        cdef unsigned char[10] cdb = [scsi.PERSISTENT_RESERVE_OUT, 0, 0, 0, 0, 0, 0, 0, 0, 0]
         cdef unsigned int data_size = 24
         cdef unsigned char[24] data
         cdef unsigned int sense_len = 32
@@ -424,12 +360,6 @@ cdef class SCSIDevice(object):
         with nogil:
             memset(data, 0, data_size)
 
-        # where the existing key would be
-        # but since we're ignoring the
-        # current key (if any) fill with 0's
-        for i in range(0, 7):
-            data[i] = 0
-
         # key to be registered
         pos = 56
         for i in range(8, 16):
@@ -439,32 +369,23 @@ cdef class SCSIDevice(object):
                 data[i] = (key >> pos) & 0xff
             pos -= 8
 
-        try:
-            self.issue_io(
-                cdb,
-                sizeof(cdb),
-                libsgio.SG_DXFER_TO_DEV,
-                data,
-                &data_size,
-                sense,
-                &sense_len,
-            )
-        except RuntimeError:
-            # no reason to continue
-            raise
+        check_sense_data = self.issue_io(
+            cdb,
+            sizeof(cdb),
+            libsgio.SG_DXFER_TO_DEV,
+            data,
+            &data_size,
+            sense,
+            &sense_len,
+        )
 
         # handle errors
-        if sense_len != 0:
-            raise OSError(self.format_sense_data(sense, sense_len))
+        if any((check_sense_data, sense_len)):
+            self.raise_error(self.format_sense_data(sense, sense_len))
 
     def reserve_key(self, key):
-        """
-        Reserves the disk (WR_EXCLUSIVE) using `key`.
-        """
-
-        cdef unsigned char[10] cdb = [
-            0x5f, 0, 0, 0, 0, 0, 0, 0, 0, 0
-        ]
+        """Reserves the disk (WR_EXCLUSIVE) using `key`."""
+        cdef unsigned char[10] cdb = [scsi.PERSISTENT_RESERVE_OUT, 0, 0, 0, 0, 0, 0, 0, 0, 0]
         cdef unsigned int data_size = 24
         cdef unsigned char[24] data
         cdef unsigned int sense_len = 32
@@ -489,43 +410,26 @@ cdef class SCSIDevice(object):
                 data[i] = (key >> pos) & 0xff
             pos -= 8
 
-        # where a new key would be put
-        # if an existing one was reserved
-        # by this host so fill with 0's
-        # since this method implies that
-        # there are no current reservations
-        # by this host
-        for i in range(8, 16):
-            data[i] = 0
-
-        try:
-            self.issue_io(
-                cdb,
-                sizeof(cdb),
-                libsgio.SG_DXFER_TO_DEV,
-                data,
-                &data_size,
-                sense,
-                &sense_len,
-            )
-        except RuntimeError:
-            # no reason to continue
-            raise
+        check_sense_data = self.issue_io(
+            cdb,
+            sizeof(cdb),
+            libsgio.SG_DXFER_TO_DEV,
+            data,
+            &data_size,
+            sense,
+            &sense_len,
+        )
 
         # handle errors
-        if sense_len != 0:
-            raise OSError(self.format_sense_data(sense, sense_len))
+        if any((check_sense_data, sense_len)):
+            self.raise_error(self.format_sense_data(sense, sense_len))
 
     def preempt_key(self, cur_key, new_key):
         """
-        Preempts an existing `cur_key` that is reserving
-        the disk and places a new reservation on the
+        Preempts an existing `cur_key` that is reserving the disk and places a new reservation on the
         disk via `new_key`
         """
-
-        cdef unsigned char[10] cdb = [
-            0x5f, 0, 0, 0, 0, 0, 0, 0, 0, 0
-        ]
+        cdef unsigned char[10] cdb = [scsi.PERSISTENT_RESERVE_OUT, 0, 0, 0, 0, 0, 0, 0, 0, 0]
         cdef unsigned int data_size = 24
         cdef unsigned char[24] data
         cdef unsigned int sense_len = 32
@@ -559,32 +463,23 @@ cdef class SCSIDevice(object):
                 data[i] = (cur_key >> pos) & 0xff
             pos -= 8
 
-        try:
-            self.issue_io(
-                cdb,
-                sizeof(cdb),
-                libsgio.SG_DXFER_TO_DEV,
-                data,
-                &data_size,
-                sense,
-                &sense_len,
-            )
-        except RuntimeError:
-            # no reason to continue
-            raise
+        check_sense_data = self.issue_io(
+            cdb,
+            sizeof(cdb),
+            libsgio.SG_DXFER_TO_DEV,
+            data,
+            &data_size,
+            sense,
+            &sense_len,
+        )
 
         # handle errors
-        if sense_len != 0:
-            raise OSError(self.format_sense_data(sense, sense_len))
+        if any((check_sense_data, sense_len)):
+            self.raise_error(self.format_sense_data(sense, sense_len))
 
     def serial(self):
-        """
-        Request serial number
-        """
-
-        cdef unsigned char[6] cdb = [
-            0x12, 0x01, 0x80, 0, 0, 0,
-        ]
+        """Request serial number"""
+        cdef unsigned char[6] cdb = [scsi.INQUIRY, 0x01, 0x80, 0, 0, 0]
         cdef unsigned int data_size = 0x00ff
         cdef unsigned char[0x00ff] data
         cdef unsigned int sense_len = 32
@@ -594,23 +489,19 @@ cdef class SCSIDevice(object):
         cdb[3] = (data_size >> 8) & 0xff
         cdb[4] = data_size & 0xff
 
-        try:
-            self.issue_io(
-                cdb,
-                sizeof(cdb),
-                libsgio.SG_DXFER_FROM_DEV,
-                data,
-                &data_size,
-                sense,
-                &sense_len,
-            )
-        except RuntimeError:
-            # no reason to continue
-            raise
+        check_sense_data = self.issue_io(
+            cdb,
+            sizeof(cdb),
+            libsgio.SG_DXFER_FROM_DEV,
+            data,
+            &data_size,
+            sense,
+            &sense_len,
+        )
 
         # handle errors
-        if sense_len != 0:
-            raise OSError(self.format_sense_data(sense, sense_len))
+        if any((check_sense_data, sense_len)):
+            self.raise_error(self.format_sense_data(sense, sense_len))
 
         # page length
         pagelen = data[3]
@@ -624,13 +515,8 @@ cdef class SCSIDevice(object):
         return serial.decode().strip().replace('\x00', '')
 
     def rotation_rate(self):
-        """
-        Request rotational rate
-        """
-
-        cdef unsigned char[8] cdb = [
-            0x12, 0x01, 0xb1, 0, 0, 0, 0, 0
-        ]
+        """Request rotational rate"""
+        cdef unsigned char[8] cdb = [scsi.INQUIRY, 0x01, 0xb1, 0, 0, 0, 0, 0]
         cdef unsigned int data_size = 0x00ff
         cdef unsigned char[0x00ff] data
         cdef unsigned int sense_len = 32
@@ -639,24 +525,18 @@ cdef class SCSIDevice(object):
         cdb[3] = (data_size >> 8) & 0xff
         cdb[4] = data_size & 0xff
 
-        try:
-            self.issue_io(
-                cdb,
-                sizeof(cdb),
-                libsgio.SG_DXFER_FROM_DEV,
-                data,
-                &data_size,
-                sense,
-                &sense_len,
-            )
-        except RuntimeError:
-            # no reason to continue
-            raise
+        check_sense_data = self.issue_io(
+            cdb,
+            sizeof(cdb),
+            libsgio.SG_DXFER_FROM_DEV,
+            data,
+            &data_size,
+            sense,
+            &sense_len,
+        )
 
         # handle errors
-        if sense_len != 0:
-            raise OSError(self.format_sense_data(sense, sense_len))
+        if any((check_sense_data, sense_len)):
+            self.raise_error(self.format_sense_data(sense, sense_len))
 
-        rotation = '0x' + f'{data[4]:02x}' + f'{data[5]:02x}'
-
-        return int(rotation, 16)
+        return int(f'0x{data[4]:02x}{data[5]:02x}', 16)

--- a/pxd/scsi.pxd
+++ b/pxd/scsi.pxd
@@ -1,0 +1,9 @@
+# cython: language_level=3, c_string_type=unicode, c_string_encoding=default
+
+
+cdef extern from "scsi/scsi.h":
+    cdef enum:
+        # opcodes
+        INQUIRY
+        PERSISTENT_RESERVE_IN
+        PERSISTENT_RESERVE_OUT

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from Cython.Build import cythonize
 
 setup(
     name='libsgio',
-    version='0.0.4',
+    version='0.1.0',
     setup_requires=[
         'setuptools>=45.0',
         'Cython',


### PR DESCRIPTION
This fixes many problems but the 3 main ones are as follows:
1. update_key() was using `6` opcode instead of `0` which means it was registering and ignoring any keys on the disk which is the exact opposite of what we wanted with that method
2. update_key() was doing `range(0, 7)` when it should be `range(0, 8)` which means it was off by one and the `cur_key` was never being packed into the buffer
3. I was not properly checking `device_status` for an error so errors were being swallowed up and not propagated to callers appropriately. (i.e. RESERVATION_CONFLICT)